### PR TITLE
버그 픽스

### DIFF
--- a/Text_RPG_Chill/Text_RPG_Chill/Program.cs
+++ b/Text_RPG_Chill/Text_RPG_Chill/Program.cs
@@ -589,12 +589,11 @@ namespace Text_RPG_Chill
 
                 if (skillInfo != 99 && SkillList[skillInfo].IsRandomTarget)
                 {
-                    List<int> randomTargetList = new List<int>();
-                    for (int i = 0; i < SkillList[skillInfo].HitChance; i++)
-                    {
-                        int x = random.Next(choicesList.Count);
-                        randomTargetList.Add(choicesList[x] - 1);
-                    }
+                    List<int> randomTargetList = choicesList
+                        .OrderBy(x => random.Next())
+                        .Take(SkillList[skillInfo].HitChance)
+                        .Select(x => x - 1)
+                        .ToList();
                     Battle(stageNum, randomTargetList, skillInfo);
                     break;
                 }
@@ -647,6 +646,11 @@ namespace Text_RPG_Chill
 
                 hitCount = SkillList[skillInfo].HitChance;
 
+            }
+
+            if (choiceMonster.Count < hitCount)
+            {
+                hitCount = choiceMonster.Count;
             }
 
             for (int i = 0; i < hitCount; i++)


### PR DESCRIPTION
1. 랜덤 타겟 정상화?
- 기술력 부족으로 인한 타겟팅 방식 변경
2. 히트카운트가 타겟보다 많을 시 버그
- 조건문으로 히트카운트를 줄이는 방식 채택